### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Handlebars.registerHelper('slice', function(context, block) {
       j = ((limit + offset) < context.length) ? (limit + offset) : context.length;
 
   for(i,j; i<j; i++) {
-    ret += block(context[i]);
+    ret += block.fn(context[i]);
   }
 
   return ret;


### PR DESCRIPTION
Fixing issue in the `slice` helper. Which were causing "Uncaught TypeError: object is not a function" error, due to incorrect use of the `block` object.
